### PR TITLE
feature: allow specify device path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ import (
 
 func main() {
 	m := mhz19.MHZ19{}
-	if err := m.Connect(); err != nil {
+    myDevicePath := "/dev/ttyS0"
+	if err := m.Connect(myDevicePath); err != nil {
 		log.Fatal(err)
 	}
 	v, err := m.ReadCO2()

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	m := mhz19.MHZ19{}
-    myDevicePath := "/dev/ttyS0"
+	myDevicePath := "/dev/ttyS0"
 	if err := m.Connect(myDevicePath); err != nil {
 		log.Fatal(err)
 	}

--- a/mhz19.go
+++ b/mhz19.go
@@ -10,8 +10,8 @@ type MHZ19 struct {
 	port *serial.Port
 }
 
-func (m *MHZ19) Connect() error {
-	c := &serial.Config{Name: "/dev/ttyS0", Baud: 9600}
+func (m *MHZ19) Connect(devicePath string) error {
+	c := &serial.Config{Name: devicePath, Baud: 9600}
 	p, err := serial.OpenPort(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
In using this module for the Orange Pi 5, the gpio pin is configured to `/dev/ttyS1`, which is different than the previously hardcoded `/dev/ttyS0`.

To make this module more universal across computers, this PR parameterizes the `devicePath` for the connection.